### PR TITLE
Update dependencies

### DIFF
--- a/gradle/project.gradle.kts
+++ b/gradle/project.gradle.kts
@@ -91,59 +91,56 @@ allprojects {
 dependencies {
 
     // Kotlin
-    compile(kotlin("stdlib-jdk8"))
-    compile(kotlin("reflect"))
-    val coroutinesVersion = "1.0.0"
-    compile("org.jetbrains.kotlinx", "kotlinx-coroutines-core", coroutinesVersion)
-    compile("org.jetbrains.kotlinx", "kotlinx-coroutines-javafx", coroutinesVersion)
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect"))
 
-    // Logging
-    compile("org.slf4j", "slf4j-api", "1.7.25")
-    compile("org.slf4j", "jul-to-slf4j", "1.7.25")
-    compile("ch.qos.logback", "logback-classic", "1.2.3")
-    compile("io.github.microutils", "kotlin-logging", "1.6.10")
-
-    // JavaFX
-    compile("de.jensd", "fontawesomefx", "8.9")
-    compile("org.reactfx", "reactfx", "2.0-M5")
-    compile("eu.hansolo", "tilesfx", "1.6.4") {
-        exclude("com.googlecode.json-simple", "json-simple")
-    }
-    compile("eu.hansolo", "Medusa", "8.0")
-
-    // Native
-    compile("net.java.dev.jna", "jna-platform", "4.5.2")
-    compile("com.1stleg", "jnativehook", "2.0.2") // don't update this to 2.1.0, it causes a critical error on linux
-
-    //Misc
-    compile("net.objecthunter", "exp4j", "0.4.8")
-    compile("org.atteo", "evo-inflector", "1.2.2")
-    compile("com.thoughtworks.xstream", "xstream", "1.4.10")
+    implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-javafx", "1.0.+")
 
     // Audio
-    compile("uk.co.caprica", "vlcj", "3.10.1")
-    compile("de.u-mass", "lastfm-java", "0.1.2")
-    compile("com.github.goxr3plus", "Jaudiotagger", "V2.2.6")
+    implementation("uk.co.caprica", "vlcj", "3.10.+")
+    implementation("de.u-mass", "lastfm-java", "0.1.2")
+    implementation("com.github.goxr3plus", "Jaudiotagger", "V2.2.6")
+
+    // JavaFX
+    implementation("de.jensd", "fontawesomefx", "8.9")
+    implementation("org.reactfx", "reactfx", "2.0-M5")
+    implementation("eu.hansolo", "tilesfx", "1.6.+") { exclude("junit", "junit") }
+    implementation("eu.hansolo", "Medusa", "8.0")
+
+    // Logging
+    implementation("org.slf4j", "slf4j-api")
+    implementation("org.slf4j", "jul-to-slf4j", "1.7.25")
+    implementation("ch.qos.logback", "logback-classic", "1.2.3")
+    implementation("io.github.microutils", "kotlin-logging", "1.6.+")
+
+    // Native
+    implementation("net.java.dev.jna", "jna-platform", "5.0.+")
+    implementation("com.1stleg", "jnativehook", "2.0.2") // don't update this to 2.1.0, it causes a critical error on linux
+
+    // Misc
+    implementation("net.objecthunter", "exp4j", "0.4.+")
+    implementation("org.atteo", "evo-inflector", "1.2.+")
+    implementation("com.thoughtworks.xstream", "xstream", "1.4.+")
 
     // Image
+    implementation("com.drewnoakes", "metadata-extractor", "2.11.0")
     val imageioVersion = "3.4.1"
-    compile("com.drewnoakes", "metadata-extractor", "2.11.0")
-    compile("com.twelvemonkeys.imageio", "imageio-core", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-bmp", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-jpeg", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-iff", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-icns", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-pcx", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-pict", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-clippath", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-hdr", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-pdf", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-pnm", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-psd", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-tga", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-sgi", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-thumbsdb", imageioVersion)
-    compile("com.twelvemonkeys.imageio", "imageio-tiff", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-bmp", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-jpeg", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-iff", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-icns", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-pcx", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-pict", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-clippath", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-hdr", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-pdf", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-pnm", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-psd", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-tga", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-sgi", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-thumbsdb", imageioVersion)
+    implementation("com.twelvemonkeys.imageio", "imageio-tiff", imageioVersion)
 
 }
 


### PR DESCRIPTION
Some updates and reordering, removing superfluous version numbers, and changing from compile to implementation since that is encouraged by Gradle.

By the way, does `imageio-thumbsdb` really have a use?