### PR TITLE
Go back to Java 11?

### DIFF
--- a/gradle/project.gradle.kts
+++ b/gradle/project.gradle.kts
@@ -66,7 +66,7 @@ allprojects {
         )
         kotlinOptions.javaParameters = true
         kotlinOptions.jdkHome = dirJdk.path
-        kotlinOptions.jvmTarget = "12"
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     repositories {
@@ -86,7 +86,7 @@ allprojects {
         }
 
         "JavaFX" group {
-            val version = "12"
+            val version = "11.0.2"
             val os = org.gradle.internal.os.OperatingSystem.current()
             val classifier = when {
                 os.isLinux -> "linux"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,12 +27,12 @@ rootProject.apply {
     include(":widgets")
     project(":widgets").apply {
         name = "widgets"
-        projectDir = file("app")
+        projectDir = file("app/widgets")
 
-        file("app/widgets").listFiles().forEach {
+        projectDir.listFiles().forEach {
             include(":widgets:${it.name}")
             project(":widgets:${it.name}").apply {
-                name = "player-widgets-${it.name}"
+                name = "widget-${it.name}"
                 projectDir = it
                 buildFileName = "../../../gradle/widgets.gradle.kts"
             }


### PR DESCRIPTION
OpenJDK builds after version 11 are not available for Ubuntu 18 LTS, going past it would force Linux users to use the Oracle JDK which may or may not be problematic in the future.

Problem: In a few places you are currently using OpenJFX 12 features, and OpenJFX 12 can not be used with JDK 11. So this does not compile right now.
This PR is not necessary here to be merged, but to record some discussion.