### PR TITLE
Implement safe file saving

### DIFF
--- a/src/player/main/sp/it/pl/core/CoreSerializer.kt
+++ b/src/player/main/sp/it/pl/core/CoreSerializer.kt
@@ -7,8 +7,10 @@ import sp.it.util.async.threadFactory
 import sp.it.util.dev.Blocks
 import sp.it.util.dev.ThreadSafe
 import sp.it.util.file.div
-import java.io.FileInputStream
-import java.io.FileOutputStream
+import sp.it.util.file.writeSafely
+import sp.it.util.functional.Try
+import sp.it.util.functional.getOrSupply
+import sp.it.util.functional.runTry
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
@@ -48,15 +50,13 @@ object CoreSerializer: Core {
 
         if (!f.exists()) return null
 
-        try {
-            FileInputStream(f).use {
-                ObjectInputStream(it).use {
-                    return it.readObject() as T
-                }
+        return runTry {
+            ObjectInputStream(f.inputStream()).use {
+                it.readObject() as T
             }
-        } catch (e: Exception) {
-            logger.error(e) { "Failed to deserialize file=$f to type=${T::class}" }
-            return null
+        }.getOrSupply {
+            logger.error(it) { "Failed to deserialize file=$f to type=${T::class}" }
+            null
         }
     }
 
@@ -66,19 +66,19 @@ object CoreSerializer: Core {
      * * any previously stored object is overwritten
      */
     @Blocks
-    inline fun <reified T: Serializable> writeSingleStorage(o: T) {
-        if (APP.rank==SLAVE) return
+    inline fun <reified T: Serializable> writeSingleStorage(o: T): Try<Nothing?, Throwable> {
+        if (APP.rank==SLAVE) return Try.ok()
 
         val f = APP.DIR_LIBRARY/(T::class.simpleName ?: T::class.jvmName)
-        try {
-            FileOutputStream(f).use {
-                ObjectOutputStream(it).use {
+        return f.writeSafely {
+            runTry {
+                ObjectOutputStream(it.outputStream()).use {
                     it.writeObject(o)
+                    null
                 }
             }
-        } catch (e: Exception) {
-            logger.error(e) { "Failed to serialize object=${o::class} to file=$f" }
-            throw e
+        }.ifError {
+            logger.error(it) { "Failed to serialize object=${o::class} to file=$f" }
         }
     }
 

--- a/src/player/main/sp/it/pl/core/CoreSerializer.kt
+++ b/src/player/main/sp/it/pl/core/CoreSerializer.kt
@@ -74,7 +74,6 @@ object CoreSerializer: Core {
             runTry {
                 ObjectOutputStream(it.outputStream()).use {
                     it.writeObject(o)
-                    null
                 }
             }
         }.ifError {

--- a/src/player/main/sp/it/pl/plugin/database/SongDb.kt
+++ b/src/player/main/sp/it/pl/plugin/database/SongDb.kt
@@ -83,7 +83,6 @@ class SongDb {
             val ms = MetadatasDB(songsById.backingMap())
             items.forEach { ms[it.id] = it }
             writeSingleStorage(ms)
-
             updateInMemoryDbFromPersisted()
         }
     }

--- a/src/util/main/sp/it/util/file/Util.kt
+++ b/src/util/main/sp/it/util/file/Util.kt
@@ -1,9 +1,9 @@
 package sp.it.util.file
 
 import mu.KotlinLogging
+import sp.it.util.dev.Blocks
 import sp.it.util.functional.Try
 import sp.it.util.functional.and
-import sp.it.util.functional.andAlso
 import sp.it.util.functional.runTry
 import java.io.File
 import java.io.FileFilter
@@ -31,12 +31,14 @@ val File.nameOrRoot: String
 val File.nameWithoutExtensionOrRoot: String get() = nameWithoutExtension.takeUnless { it.isEmpty() } ?: toString()
 
 /** @return file itself if exists or its first existing parent or error if null or no parent exists */
+@Blocks
 fun File.find1stExistingParentFile(): Try<File, Nothing?> = when {
     exists() -> Try.ok(this)
     else -> parentDir?.find1stExistingParentFile() ?: Try.error()
 }
 
 /** @return first existing directory in this file's hierarchy or error if no parent exists */
+@Blocks
 fun File.find1stExistingParentDir(): Try<File, Nothing?> = when {
     exists() && isDirectory -> Try.ok(this)
     else -> parentDir?.find1stExistingParentDir() ?: Try.error()
@@ -50,12 +52,16 @@ fun File.childOf(childName: String) = File(this, childName)
 
 fun File.childOf(vararg childNames: String) = childNames.fold(this, File::childOf)
 
+@Blocks
 infix fun File.isChildOf(parent: File) = parent.isParentOf(this)
 
+@Blocks
 infix fun File.isAnyChildOf(parent: File) = parent.isAnyParentOf(this)
 
+@Blocks
 infix fun File.isParentOf(child: File) = child.parentDir==this
 
+@Blocks
 infix fun File.isAnyParentOf(child: File) = generateSequence(child) { it.parentDir }.any { isParentOf(it) }
 
 /**
@@ -120,6 +126,7 @@ fun File.toURLOrNull() =
  * * [SecurityException] when security manager exists and file write is not permitted
  * * [java.io.IOException] when error occurs while writing to the file output stream
  */
+@Blocks
 @JvmOverloads
 fun File.writeTextTry(text: String, charset: Charset = Charsets.UTF_8) = runTry { writeText(text, charset) }
 
@@ -131,49 +138,92 @@ fun File.writeTextTry(text: String, charset: Charset = Charsets.UTF_8) = runTry 
  * * [java.io.IOException] when error occurs while reading from the file input stream
  * * [OutOfMemoryError] when file is too big
  */
+@Blocks
 @JvmOverloads
 fun File.readTextTry(charset: Charset = Charsets.UTF_8) = runTry { readText(charset) }
 
 /**
- *  Invokes the specified block that saves the file with safe temporary file saving semantics:
- *  - 1 remove temporary file if exists
- *  - 2 rename existing file to temporary file
- *  - 3 invoke block to save the file
- *  - if 3 succeeds remove the temporary file
- *  - if 3 fails rename the temporary file to original file
+ * Invokes the specified block that saves this file (from now on TARGET file) with safe temporary file saving
+ * semantics. In order to guarantee no loss of data (not even on on subsequent failures of subsequent repeat of this
+ * function) it uses two temporary files WRITE for writing new data and BACKUP for storing original data.
  *
- *  Calling this method concurrently (on the same file) will result in unpredictable behavior.
+ * Steps:
+ * - 1 write to WRITE file (overwrites any existing file)
+ *   - 1.1 if 1 fails delete WRITE file (this can also fail, but that is inconsequential, it's mere cleanup)
+ * - 2 delete existing BACKUP file (safe, TARGET file contains original data, BACKUP file is from previous invocation)
+ *   - if 2 fails we still have original data in TARGET, which we haven't touched
+ * - 3 rename TARGET file to BACKUP file, i.e., make backup
+ *   - if 3 fails we still have original data in TARGET, which we haven't touched
+ * - 4 rename WRITE file to TARGET file
+ *   - 4.1 if 4 fails reverse 3 - rename BACKUP back to TARGET, on success everything is well, on fail we at least still
+ *     have original data in BACKUP (although user will have to manually recover the data)
+ * - 5 delete BACKUP file
  *
- *  @return ok if all steps succeed, error otherwise
+ * Guarantees:
+ * - TARGET file never contains corrupted data (although it may not exist)
+ * - BACKUP file never contains corrupted data (although it may not exist)
+ * - TARGET or BACKUP exists, i.e, data is never lost
+ *
+ * Notable:
+ * - WRITE file may contain corrupted data, but may also contain valid, more actual data than BACKUP
+ * - If this functions returns Ok, every step succeeded and no temporary files are left behind
+ * - If this functions returns Error, data writing still may have succeeded and may even be in the TARGET file, but
+ * one of the steps 1-5 failed and there may also be temporary files left behind.
+ *
+ * Concurrency:
+ * Calling this function concurrently (on the same file) will result in unpredictable behavior. It is highly advised
+ * to use synchronization, but preferably per file locks to guarantee exclusivity of this call:
+ * ```
+ * file1Lock.withLock {
+ *     file1.writeSafely { ... }
+ * }
+ * ```
+ * This function is blocking and returns only after all io take place, i.e., is thread-safe in single threaded environment.
+ *
+ * @return ok if steps 1 and 2 and 3 and 4 and 5 succeed, error otherwise
  */
-fun <OK> File.writeSafely(block: (File) -> Try<OK, Throwable>): Try<OK, Throwable> {
-    val f = absoluteFile
-    val fTmp = f.resolveSibling("$name.tmp")
+@Blocks
+fun File.writeSafely(block: (File) -> Try<*, Throwable>): Try<Nothing?, Throwable> {
 
-    return runTry {
-        Files.deleteIfExists(fTmp.toPath())
+    fun File.tryRenameIfExists(to: File, message: () -> String) = if (!exists() || renameTo(to)) Try.ok() else Try.error(Exception(message()))
+
+    fun File.tryDeleteIfExists(message: (Throwable) -> String) = runTry {
+        Files.deleteIfExists(toPath())
     }.mapError {
-        Exception("Safe writing of $f failed. Data was not saved as deleting the previous temporary backup file='$fTmp' failed", it)
-    }.and {
-        if (!f.exists() || f.renameTo(fTmp)) Try.ok()
-        else Try.error(Exception("Safe writing of $f failed. Data was not saved as renaming previous file to temporary backup file=`$fTmp` failed"))
-    }.andAlso {
-        block(
-            f
-        ).mapError {
-            Exception("Safe writing of $f failed. Data was not saved as ${it.message}", it)
-        }.and {
-            runTry {
-                Files.deleteIfExists(fTmp.toPath())
-            }.mapError {
-                Exception("Safe writing of $f failed. Data was saved, but deleting temporary backup file '$fTmp' failed", it)
-            }
+        Exception(message(it), it)
+    }
+
+    val f = absoluteFile
+    val fW = f.resolveSibling("$name.w.tmp")
+    val fR = f.resolveSibling("$name.tmp")
+
+    return run {
+        run {
+            block(fW)
+        }.mapError {
+            Exception("Safe writing of `$f` failed. Data was not saved to temporary file=`$fW` as ${it.message}", it)
         }.ifError {
-            runTry {
-                Files.deleteIfExists(f.toPath())
-            }.ifOk {
-                fTmp.renameTo(f)
-            }
+            fW.tryDeleteIfExists { "Deleting $fW failed" }
         }
+    }.and {
+        fR.tryDeleteIfExists {
+            "Safe writing of $f failed. Data was saved to temporary file=`$fW`, but deleting temporary backup file=`$fR` failed"
+        }
+    }.and {
+        f.tryRenameIfExists(fR) {
+            "Safe writing of $f failed. Data was saved to temporary file=`$fW`, but renaming file=`$f` to temporary backup file=`$fR` failed"
+        }
+    }.and {
+        fW.tryRenameIfExists(f) {
+            "Safe writing of $f failed. Data was saved to temporary file=`$fW`, but renaming it to file=`$f` failed"
+        }.ifError {
+            fR.tryRenameIfExists(f) { "Renaming file=`$fR` to file=`$f` failed" }
+        }
+    }.and {
+        fR.tryDeleteIfExists {
+            "Safe writing of $f failed. Data was saved, but deleting temporary backup file=`$fR` failed"
+        }
+    }.map {
+        null
     }
 }


### PR DESCRIPTION
Implements file saving using the tmp file strategy & uses it across the project where necessary.

The saving method, as is (IMPL1), remains problematic, due to the fact that data can still be lost, however the advised method of saving to tmp first and then renaming (IMPL2) is also problematic and I do not know which is worse.

Currently the issue is that if file saving succeeds, we need to delete the tmp file, but this can fail and if it does the application has to move on, which means next time the same operation is called, we either always fail (which absolutely necessitates user solving this manually, which is bad) or we proceed by first removing the tmp file, which can lead to disastrous loss of data if the previous operation actually failed in the middle of the write (causing tmp now contain broken data) and this operation failed also - leading to no data and no backup. This could seemingly be solved by deleting the save file on error to guarantee it never contains corrupt data, unfortunately this can never be avoided as the delete can fail too.

So we either force user to take care of it in order to prevent app never being able to save again (this is how Intellij Idea does it with commit fails - user must delete .git/.lock file) or we allow the (very rare) possibility of data loss.

Another problem is the cleanup logic in case writing fails - we have no way to provide the error back to the caller as we now have two errors we want to report and this is an odd situation to be in.

The IMPL2 suggested in the previous PR also has both these issues (two consequent failures may lead to complete data loss).

So what now?

The idea of save file, or backup file containing corrupt data does not sit well with me in the first place. Perhaps the writing could save into a .tmp.write file, which would be renamed upon success, this would guarantee no corrupt data. Any ideas?