### PR TITLE
Fix linkJdk task

### DIFF
--- a/buildSrc/src/main/kotlin/GradleUtil.kt
+++ b/buildSrc/src/main/kotlin/GradleUtil.kt
@@ -2,6 +2,7 @@
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.JavaVersion
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
@@ -28,7 +29,7 @@ open class LinkJDK: DefaultTask() {
    /** Not used directly, but useful to automatically trigger the task if the java version changes. */
    @Input lateinit var jdkVersion: JavaVersion
    /** Location of the link to the JDK. */
-   @Input lateinit var linkLocation: File
+   @Input @Internal lateinit var linkLocation: File
 
    @TaskAction
    fun linkJdk() {
@@ -41,7 +42,7 @@ open class LinkJDK: DefaultTask() {
          println("Couldn't create a symbolic link at $linkLocation to $jdkPath: $e")
          val isWindows = "os.name".sysProp?.startsWith("Windows")==true
          if (isWindows) {
-            println("Trying junction...")
+            println("Trying to create a Windows junction instead...")
             val process = Runtime.getRuntime().exec("""cmd.exe /c mklink /j "$linkLocation" "$jdkPath"""")
             val exitValue = process.waitFor()
             if (exitValue==0 && linkLocation.exists()) println("Junction successful!")

--- a/buildSrc/src/main/kotlin/GradleUtil.kt
+++ b/buildSrc/src/main/kotlin/GradleUtil.kt
@@ -34,18 +34,18 @@ open class LinkJDK: DefaultTask() {
    @TaskAction
    fun linkJdk() {
       linkLocation.delete() // delete invalid symbolic link
-      println("Linking JDK to project relative directory...")
       val jdkPath = "java.home".sysProp?.let { Paths.get(it) } ?: failIO { "Unable to find JDK" }
+      logger.info("Creating link at $linkLocation to $jdkPath...")
       try {
          Files.createSymbolicLink(linkLocation.toPath(), jdkPath)
       } catch (e: Exception) {
-         println("Couldn't create a symbolic link at $linkLocation to $jdkPath: $e")
+         logger.warn("Couldn't create a symbolic link at $linkLocation to $jdkPath: $e")
          val isWindows = "os.name".sysProp?.startsWith("Windows")==true
          if (isWindows) {
-            println("Trying to create a Windows junction instead...")
+            logger.info("Trying to create a Windows junction instead...")
             val process = Runtime.getRuntime().exec("""cmd.exe /c mklink /j "$linkLocation" "$jdkPath"""")
             val exitValue = process.waitFor()
-            if (exitValue==0 && linkLocation.exists()) println("Junction successful!")
+            if (exitValue==0 && linkLocation.exists()) logger.info("Successfully created junction!")
             else failIO(e) { "Unable to make JDK locally accessible!\nmklink exit code: $exitValue" }
          } else {
             failIO(e) { "Unable to make JDK locally accessible!" }

--- a/gradle/project.gradle.kts
+++ b/gradle/project.gradle.kts
@@ -198,7 +198,7 @@ tasks {
    val linkJdk by creating(LinkJDK::class) {
       group = "build setup"
       description = "Links JDK to project relative directory"
-      linkDir = dirJdk
+      linkLocation = dirJdk
       jdkVersion = javaVersion
    }
 

--- a/gradle/project.gradle.kts
+++ b/gradle/project.gradle.kts
@@ -199,7 +199,6 @@ tasks {
       group = "build setup"
       description = "Links JDK to project relative directory"
       linkLocation = dirJdk
-      jdkVersion = javaVersion
    }
 
    val kotlinc by creating(Download::class) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I am currently not able to build the project due to https://github.com/gradle/gradle/issues/9985, so this PR provides a fix. Furthermore, I think it does not make sense to scan the location as an output directory, because it is not of interest to this task.